### PR TITLE
이미지 0바이트인 상태에서 전달되는 버그 수정 

### DIFF
--- a/src/main/java/com/example/techtitansserver/domain/inspection/Service/AiService.java
+++ b/src/main/java/com/example/techtitansserver/domain/inspection/Service/AiService.java
@@ -26,13 +26,10 @@ public class AiService {
     private final RestClient restClient;
     private final ObjectMapper objectMapper = new ObjectMapper();
 
-    public String sendImageToAiServer(MultipartFile multipartFile) throws IOException {
+    public String sendImageToAiServer(FileSystemResource fileSystemResource) throws IOException {
 
-        Path tempFile = Files.createTempFile("upload", multipartFile.getOriginalFilename());
-
-        FileSystemResource fileResource = new FileSystemResource(tempFile.toFile());
         MultiValueMap<String, Object> parts = new LinkedMultiValueMap<>();
-        parts.add("imageFile", fileResource);
+        parts.add("imageFile", fileSystemResource);
 
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.MULTIPART_FORM_DATA);

--- a/src/main/java/com/example/techtitansserver/domain/inspection/Service/InspectionService.java
+++ b/src/main/java/com/example/techtitansserver/domain/inspection/Service/InspectionService.java
@@ -9,6 +9,7 @@ import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.FileSystemResource;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -24,12 +25,12 @@ public class InspectionService {
     private final AiService aiService;
 
     public InspectionResultResponseDto checkSurfaceWithImage(MultipartFile multipartFile) throws IOException {
+        String savedFilePath = fileHandler.saveFile(multipartFile);
 
-        String resultData = aiService.sendImageToAiServer(multipartFile);
-
+        FileSystemResource fileSystemResource = new FileSystemResource(savedFilePath);
         // inspectionResult에서 결함 종류/ 범위 추출해서 등급(rating) 계산
 
-        String savedFilePath = fileHandler.saveFile(multipartFile);
+        String resultData = aiService.sendImageToAiServer(fileSystemResource);
         String savedFileName = new File(savedFilePath).getName();
         String url = fileURL + "/" + savedFileName;
 


### PR DESCRIPTION
이미지 0바이트인 상태에서 전달되는 버그 수정했습니다.

스프링부트에서 multipartfile -> file로 변환하는 코드를 flask에 이미지 전달하기 전에 진행했습니다.

![image](https://github.com/user-attachments/assets/aa15ff23-effc-4b5d-a9e8-027b5538fde1)
